### PR TITLE
docs: linted .md files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,12 +7,14 @@ We are committed to making participation in our project a harassment-free experi
 ## Our Standards
 
 Examples of behavior that contribute to a positive environment include:
+
 - Being respectful and considerate in communication
 - Actively listening and providing constructive feedback
 - Welcoming new contributors and helping them grow
 - Accepting differing viewpoints and experiences
 
 Examples of unacceptable behavior include:
+
 - Personal insults, discriminatory or derogatory comments
 - Harassment, threats, or intimidation
 - Publishing others’ private information without consent
@@ -21,6 +23,7 @@ Examples of unacceptable behavior include:
 ## Our Responsibilities
 
 Maintainers are responsible for:
+
 - Clarifying standards of acceptable behavior
 - Reviewing and addressing any reported instances of misconduct
 - Removing or modifying unacceptable comments, commits, code, and contributions
@@ -31,8 +34,9 @@ This Code of Conduct applies within all project spaces (GitHub repositories, Dis
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing **openbiocure@gmail.com**. All reports will be handled with confidentiality.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing **<openbiocure@gmail.com>**. All reports will be handled with confidentiality.
 
 ## Attribution
 
 This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,34 +9,41 @@ This project is part of the **OpenBioCure** initiative and welcomes contribution
 ## 📌 How to Contribute
 
 ### 1. Fork the Repository
+
 Create a personal copy of the project by forking it to your GitHub account.
 
 ### 2. Clone Your Fork
+
 ```
 git clone https://github.com/<your-username>/HerpAI.git
 cd HerpAI
 ```
 
 ### 3. Create a New Branch
+
 ```
 git checkout -b feature/my-feature-name
 ```
 
 ### 4. Make Your Changes
+
 Please keep your code modular, clean, and well-commented. Add tests where applicable.
 
 ### 5. Commit and Push
+
 ```
 git commit -m "Add new feature/fix"
 git push origin feature/my-feature-name
 ```
 
 ### 6. Submit a Pull Request (PR)
+
 Create a PR against the `main` branch with a clear description of your changes.
 
 ---
 
 ## 📂 Areas You Can Help With
+
 - Writing or improving AI agents (VirologyAgent, DrugDesignAgent, etc.)
 - Prompt engineering and prompt testing
 - Enhancing the orchestrator or API interface
@@ -48,6 +55,7 @@ Create a PR against the `main` branch with a clear description of your changes.
 ---
 
 ## 📋 Code Guidelines
+
 - Use **clear naming conventions** and keep modules self-contained
 - Add **docstrings and comments** to explain logic
 - Structure code in alignment with the project architecture
@@ -76,6 +84,7 @@ Please structure your commits as follows:
 - `ci`: Continuous Integration/Deployment related changes
 
 ✅ Example:
+
 ```
 feat(agent): add CRISPRDesignAgent prompt template
 docs: update README with simulation sample
@@ -86,13 +95,16 @@ docs: update README with simulation sample
 ---
 
 ## 📢 Communication
+
 If you want to discuss your contribution idea or ask questions, feel free to:
+
 - Open a GitHub Issue
 - Start a Discussion (coming soon)
-- Email: **openbiocure@gmail.com**
+- Email: **<openbiocure@gmail.com>**
 
 ---
 
 Let's build something powerful — together.
 
 **– The OpenBioCure Project**
+

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,17 +5,21 @@ HerpAI is an open-source project dedicated to accelerating the discovery of real
 We are deeply grateful to everyone who contributes their time, skills, and creativity to help build this community-driven initiative.
 
 ## 👩‍💻 Code Contributors
+
 - Mohammad Chehab – Project creator and core developer  
 - [Add your name here by submitting a PR]
 
 ## 🎨 Design & UX Contributors
+
 - [Seeking volunteer designers — logo, branding, and Figma wireframes]
 - [Add your name here once you contribute design work]
 
 ## 📄 Documentation & Knowledge Contributors
+
 - [Add your name here once you've contributed to docs, explanations, or scientific content]
 
 ## 📣 Community & Outreach Support
+
 - [Add your name here if you've helped share or promote HerpAI in open science communities]
 
 ---
@@ -24,3 +28,4 @@ Want to contribute?
 Check out the [GitHub issues](https://github.com/openbiocure/HerpAI/issues) labeled `help wanted` or `design`.
 
 Let’s build this together — for open science, for real cures.
+

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -3,7 +3,9 @@
 ---
 
 ## 1. Objective
+
 Establish a modular, scalable, AI-powered discovery pipeline for HSV-2 therapeutic targeting using both:
+
 - LLM-based reasoning agents (prompt-driven)
 - ML-based analytical models (data-driven)
 
@@ -71,6 +73,7 @@ Visual chaining can be supported later via Langflow-compatible task graphing.
 ## 7. Confidence Index / Scoring Layer
 
 Each agent’s output should be:
+
 - Post-processed via a scoring model (mock or trained)
 - Annotated with P-Value or Confidence Score
 - Thresholded before final report generation
@@ -99,3 +102,4 @@ Each agent’s output should be:
 - [ ] Begin dataset gathering scripts  
 - [ ] Scaffold `data/curation/` module for ML dataset cleaning  
 - [ ] Extend RAG system to auto-index new papers  
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
-## 🛣 Roadmap
+# 🛣 Roadmap
 
 The HerpAI roadmap outlines major development milestones, agent expansion plans, and areas open for collaboration.
 
-### 🔖 Visionary Milestones
+## 🔖 Visionary Milestones
 
 - 🌐 Establish HerpAI as an open, modular platform for AI-driven drug discovery
 - 🧠 Demonstrate multi-agent collaboration for molecular target identification and treatment design
@@ -12,30 +12,38 @@ The HerpAI roadmap outlines major development milestones, agent expansion plans,
 - 📄 Publish and maintain an open whitepaper and research framework on HSV cure discovery
 - 🚀 Set the foundation for expanding HerpAI into broader bio-cure discovery beyond HSV
 
-### 📌 Upcoming Features, Stories, and Tasks
+## 📌 Upcoming Features, Stories, and Tasks
 
-#### 🚀 Feature: Agent Expansion
+### 🚀 Feature: Agent Expansion
+
 - [ ] Story: Build TargetPrioritizationAgent to prioritize molecular targets based on virology output
 - [ ] Story: Develop DrugDesignAgent to generate SMILES-based drug candidates using LLM
 - [ ] Story: Implement CRISPRDesignAgent to propose CRISPR guide sequences targeting HSV genes
 
-#### 📊 Feature: Scientific Report Engine
+### 📊 Feature: Scientific Report Engine
+
 - [ ] Story: Add logic for generating structured scientific reports from agent outputs
 - [ ] Task: Create sample report templates in Markdown and PDF format
 
-#### 🧠 Feature: Multi-Model Abstraction Layer
+### 🧠 Feature: Multi-Model Abstraction Layer
+
 - [ ] Story: Extend ModelRouter to support local LLM providers (e.g., Mistral, LLaMA)
 - [ ] Task: Add fallback mechanism between providers in ModelRouter
 
-#### 🧪 Feature: Testing & Validation
+### 🧪 Feature: Testing & Validation
+
 - [ ] Story: Add unit tests for all agents and core utilities
 - [ ] Task: Add integration tests for multi-agent execution pipeline
 
-#### 💻 Feature: Optional Frontend Interface
+### 💻 Feature: Optional Frontend Interface
+
 - [ ] Story: Build lightweight UI interface using Streamlit or Gradio to run agents interactively
 
-#### 📄 Feature: Whitepaper Publication
+### 📄 Feature: Whitepaper Publication
+
 - [ ] Story: Draft and finalize the HerpAI whitepaper for public scientific release
 
-#### 🔧 Feature: Developer Productivity Tooling
+### 🔧 Feature: Developer Productivity Tooling
+
 - [ ] Task: Setup CI/CD automation with GitHub Actions for testing and linting
+


### PR DESCRIPTION
In this PR, most .md files of the root directory were linted. Skipped `README.md` because #16 already linted this file. This reduces the amount of warnings in markdownlint report output.